### PR TITLE
Fix for issue #2 when comparing numbers other than double

### DIFF
--- a/src/main/java/org/jspringbot/keyword/json/JSONHelper.java
+++ b/src/main/java/org/jspringbot/keyword/json/JSONHelper.java
@@ -35,6 +35,7 @@ import org.springframework.core.io.ResourceEditor;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
@@ -176,15 +177,16 @@ public class JSONHelper {
 
     public void jsonValueShouldBe(String jsonExpression, String expectedValue) {
         Object jsonValue = getJsonValue(jsonExpression);
-
+        
         if (Number.class.isInstance(jsonValue)) {
-            Double expectedNumberValue = Double.valueOf(expectedValue);
-            if (!expectedNumberValue.equals(jsonValue)) {
-                throw new IllegalArgumentException(String.format("Expecting '%s' json value but was '%s'",expectedValue,String.valueOf(jsonValue)));
+            BigDecimal expectedNumberValue = new BigDecimal(expectedValue);
+            BigDecimal jsonNumberValue = new BigDecimal(jsonValue.toString());
+            if (!expectedNumberValue.equals(jsonNumberValue)) {
+                throw new IllegalArgumentException(String.format("Expecting '%s' json number value but was '%s'",expectedValue,String.valueOf(jsonValue)));
             }
         } else {
             if (!expectedValue.equals(String.valueOf(jsonValue))) {
-                throw new IllegalArgumentException(String.format("Expecting '%s' json value but was '%s'",expectedValue,String.valueOf(jsonValue)));
+                throw new IllegalArgumentException(String.format("Expecting '%s' json string value but was '%s'",expectedValue,String.valueOf(jsonValue)));
             }
         }
     }

--- a/src/test/java/org/jspringbot/keyword/json/JSONHelperTest.java
+++ b/src/test/java/org/jspringbot/keyword/json/JSONHelperTest.java
@@ -77,17 +77,12 @@ public class JSONHelperTest {
 		List<Object> jsonValues = helper.getJsonValues("store.book[*]");
 
 		assertEquals(jsonValues.size(), 4);
-
-		assertEquals(jsonValues.get(0).toString(),
-				"{category=reference, author=Nigel Rees, title=Sayings of the Century, price=8.95}");
-		assertEquals(jsonValues.get(1).toString(),
-				"{category=fiction, author=Evelyn Waugh, title=Sword of Honour, price=12.99}");
-		assertEquals(jsonValues.get(2).toString(),
-				"{category=fiction, author=Herman Melville, title=Moby Dick, isbn=0-553-21311-3, price=8.99}");
-		assertEquals(jsonValues.get(3).toString(),
-				"{category=fiction, author=J. R. R. Tolkien, title=The Lord of the Rings, isbn=0-395-19395-8, price=22.99}");
-
-	}
+		
+		assertEquals(jsonValues.get(0).toString(), "{category=reference, author=Nigel Rees, title=Sayings of the Century, price=8.95}");
+		assertEquals(jsonValues.get(1).toString(), "{category=fiction, author=Evelyn Waugh, title=Sword of Honour, price=12.99}");
+		assertEquals(jsonValues.get(2).toString(), "{category=fiction, author=Herman Melville, title=Moby Dick, isbn=0-553-21311-3, price=8.99}");
+		assertEquals(jsonValues.get(3).toString(), "{category=fiction, author=J. R. R. Tolkien, title=The Lord of the Rings, isbn=0-395-19395-8, price=22.99}");
+				
 
 	@Test
 	public void testJsonValueShouldBeNumbers() throws Exception {

--- a/src/test/java/org/jspringbot/keyword/json/JSONHelperTest.java
+++ b/src/test/java/org/jspringbot/keyword/json/JSONHelperTest.java
@@ -68,7 +68,7 @@ public class JSONHelperTest {
 
 		assertEquals(jsonValue, "yes");
 	}
-	
+
 	@Test
 	public void testMultipleValuesPath() throws Exception {
 
@@ -77,11 +77,36 @@ public class JSONHelperTest {
 		List<Object> jsonValues = helper.getJsonValues("store.book[*]");
 
 		assertEquals(jsonValues.size(), 4);
-		
-		assertEquals(jsonValues.get(0).toString(), "{category=reference, author=Nigel Rees, title=Sayings of the Century, price=8.95}");
-		assertEquals(jsonValues.get(1).toString(), "{category=fiction, author=Evelyn Waugh, title=Sword of Honour, price=12.99}");
-		assertEquals(jsonValues.get(2).toString(), "{category=fiction, author=Herman Melville, title=Moby Dick, isbn=0-553-21311-3, price=8.99}");
-		assertEquals(jsonValues.get(3).toString(), "{category=fiction, author=J. R. R. Tolkien, title=The Lord of the Rings, isbn=0-395-19395-8, price=22.99}");
-				
+
+		assertEquals(jsonValues.get(0).toString(),
+				"{category=reference, author=Nigel Rees, title=Sayings of the Century, price=8.95}");
+		assertEquals(jsonValues.get(1).toString(),
+				"{category=fiction, author=Evelyn Waugh, title=Sword of Honour, price=12.99}");
+		assertEquals(jsonValues.get(2).toString(),
+				"{category=fiction, author=Herman Melville, title=Moby Dick, isbn=0-553-21311-3, price=8.99}");
+		assertEquals(jsonValues.get(3).toString(),
+				"{category=fiction, author=J. R. R. Tolkien, title=The Lord of the Rings, isbn=0-395-19395-8, price=22.99}");
+
 	}
+
+	@Test
+	public void testJsonValueShouldBeNumbers() throws Exception {
+
+		helper.setJsonString(getJson("classpath:numbers.json"));
+
+		helper.jsonValueShouldBe("empty", "");
+		helper.jsonValueShouldBe("zero", "0");
+		helper.jsonValueShouldBe("integer", "10");
+		helper.jsonValueShouldBe("integer-neg", "-15");
+		helper.jsonValueShouldBe("long", "12345678901");
+		helper.jsonValueShouldBe("long-neg", "-10987654321");
+		helper.jsonValueShouldBe("double", "123456.0");
+		helper.jsonValueShouldBe("double-neg", "-654.321");
+		helper.jsonValueShouldBe("double-tiny", "0.000000000000000000000123");
+		helper.jsonValueShouldBe("bigdecimal", "1234567890123456789.0");
+		helper.jsonValueShouldBe("bigdecimal-neg", "-98765432109876543210.0");
+		helper.jsonValueShouldBe("non-number", "abc");
+
+	}
+
 }

--- a/src/test/resources/numbers.json
+++ b/src/test/resources/numbers.json
@@ -1,0 +1,14 @@
+{
+	"empty": "",
+	"zero": 0,
+    "integer": 10,
+    "integer-neg": -15,
+    "long": 12345678901,
+    "long-neg": -10987654321,
+    "double": 123456.0,
+    "double-neg": -654.321,
+    "double-tiny": 0.000000000000000000000123,
+    "bigdecimal": 1234567890123456789.0,
+    "bigdecimal-neg": -98765432109876543210.0,
+    "non-number": "abc"
+}


### PR DESCRIPTION
This is a fix for the issue #2 when comparing numbers other than double. The code assumed the number to be Double, but the JsonPath returns others too ie. Long,

The workaround is to use BigDecimal as an intermediate class. See for example discussion here:

http://stackoverflow.com/questions/12561485/how-to-compare-two-numbers-in-java

There isn't really anything fool proof, but this approach should take care at least most common situations. Special handlers can be added if needed.